### PR TITLE
Simplify form of cryptosystem

### DIFF
--- a/krypto-lib/src/main/cpp/BitMatrix.h
+++ b/krypto-lib/src/main/cpp/BitMatrix.h
@@ -406,7 +406,7 @@ public:
      * Function: copy(m)
      * Copies a given matrix to the current one
      */
-	void copy(const BitMatrix<ROWS, COLS> &m) {
+	void copy(const BitMatrix<ROWS, COLS> &m) const {
 		for (size_t i = 0; i < ROWS; ++i)
 			(_rows[i]).copy(m.getRow(i));
 	}

--- a/krypto-lib/src/main/cpp/BitVector.h
+++ b/krypto-lib/src/main/cpp/BitVector.h
@@ -361,7 +361,7 @@ public:
      * Function: copy(rhs)
      * Copies a given vector into the current one
      */
-    void copy(const BitVector<NUM_BITS> & v) {
+    void copy(const BitVector<NUM_BITS> & v) const {
         memcpy(this->elements(), v.elements(), sizeof(v));
     }
 

--- a/krypto-lib/src/main/cpp/ClientHashFunction.h
+++ b/krypto-lib/src/main/cpp/ClientHashFunction.h
@@ -47,9 +47,8 @@ struct ClientHashFunction
 	void generateHashMatrix(const BitMatrix<N, 2*N> & K, const PrivateKey<N> & pk){
 		const BitMatrix<2*N> & Mi = pk.getM().inv();
 		const BitMatrix<N, 2*N> & Mi1 = Mi.splitV2(0);
-		const BitMatrix<N, 2*N> & Mi2 = Mi.splitV2(1);
 
-		const BitMatrix<N, 2*N> & decryptMatrix = pk.getB().inv() * (Mi1 ^ pk.getA().inv() * Mi2);
+		const BitMatrix<N, 2*N> & decryptMatrix = Mi1;
 
 		const BitMatrix<N, 2*N> & zero = BitMatrix<N, 2*N>::zeroMatrix();
 		const BitMatrix<N, 4*N> & top = BitMatrix<N, 4*N>::augH(decryptMatrix, zero);
@@ -64,7 +63,7 @@ struct ClientHashFunction
      */
 	const MultiQuadTuple<2*N, N> generateAugmentedF2(const BitMatrix<N> & C, const BitMatrix<N, 2*N> & K, const PrivateKey<N> & pk) const{
 		MultiQuadTuple<N, N> f2 = pk.getf().get(1);
-		MultiQuadTuple<N, N> topBot = (f2 * C).rMult(pk.getB().inv());
+		MultiQuadTuple<N, N> topBot = f2 * C;
 
         const BitMatrix<N> & I = BitMatrix<N>::identityMatrix();
         const BitMatrix<N> & O = BitMatrix<N>::zeroMatrix();
@@ -83,8 +82,7 @@ struct ClientHashFunction
      */
 	 const MultiQuadTuple<2*N, N> generateConcealedF1(const BitMatrix<N> & C, const PrivateKey<N> & pk) const{
 		MultiQuadTuple<N, N> f1 = pk.getf().get(0);
-		const BitMatrix<N, 2*N> & Mi2 = pk.getM().inv().splitV2(1);
-		const BitMatrix<N, 2*N> & inner = pk.getA().inv() * Mi2;
+		const BitMatrix<N, 2*N> & inner = pk.getM().inv().splitV2(1);
 		return (f1 * inner).rMult(C.inv());
 	}
 

--- a/krypto-lib/src/main/cpp/PrivateKey.h
+++ b/krypto-lib/src/main/cpp/PrivateKey.h
@@ -33,8 +33,6 @@ public:
      * Constructs a PrivateKey with randomly initialized private variables
      */
 	PrivateKey():
-		_A(BitMatrix<N>::randomInvertibleMatrix()),
-		_B(BitMatrix<N>::randomInvertibleMatrix()),
 		_M(BitMatrix<2*N>::randomInvertibleMatrix()),
 		_f(MultiQuadTupleChain<N,2>::randomMultiQuadTupleChain()){
 		generateObfuscationMatrixChains();
@@ -46,8 +44,8 @@ public:
      */
 	const BitVector<2*N> encrypt(const BitVector<N> &m) const{//returns x = E(m, r) given a plaintext m
 		const BitVector<N> & r = BitVector<N>::randomVector();
-		const BitVector<N> & top = (_B * m) ^ (r ^ _f(r));
-		const BitVector<N> & bottom = _A * r;
+		const BitVector<N> & top = m ^ _f(r);
+		const BitVector<N> & bottom = r;
 		return _M * BitVector<N>::vCat(top, bottom);
 	}
 
@@ -59,20 +57,11 @@ public:
 		const BitVector<2*N> & mix = _M.solve(x);
 		BitVector<N> x1, x2;
 		mix.proj(x1, x2);
-		const BitVector<N> & Aix2 = _A.solve(x2);
-		const BitVector<N> & fAix2 = _f(Aix2);
-		return _B.solve(x1 ^ (Aix2 ^ fAix2));
+		const BitVector<N> & fx2 = _f(x2);
+		return x1 ^ fx2;
 	}
 
 protected:
-	const BitMatrix<N> getA() const{
-		return _A;
-	}
-
-	const BitMatrix<N> getB() const{
-		return _B;
-	}
-
 	const BitMatrix<2*N> getM() const{
 		return _M;
 	}
@@ -98,7 +87,6 @@ protected:
 	}
 
 private:
-	const BitMatrix<N> _A, _B; //SL_n(F_2)
 	const BitMatrix<2*N> _M; //SL_{2n}(F_2)
 	MultiQuadTupleChain<N,2> _f; //{f_1,...,f_L} random quadratic function tuples
 	BitMatrix<2*N> _Cu[2]; //chain of obfuscation matrix for unary operations

--- a/krypto-lib/src/main/cpp/PublicKey.h
+++ b/krypto-lib/src/main/cpp/PublicKey.h
@@ -26,8 +26,6 @@ public:
 	_lc(bk.getLeftColumnMatrix()),
 	_gu1(bk.getUnaryG1()),
 	_gu2(bk.getUnaryG2()),
-	_gb1(bk.getBinaryG1()),
-	_gb2(bk.getBinaryG2()),
 	_XOR(bk.getXOR()),
 	_AND(bk.getAND())
 	{
@@ -38,11 +36,11 @@ public:
 	}
 
 	const BitVector<2*N> homomorphicXOR(const BitVector<2*N> &x, const BitVector<2*N> &y) const{
-		return _XOR(x, y, binaryT(x, y));
+		return _XOR(x, y);
 	}
 
 	const BitVector<2*N> homomorphicAND(const BitVector<2*N> &x, const BitVector<2*N> &y) const{
-		return _AND(x, y, binaryT(x, y));
+		return _AND(x, y);
 	}
 
 	//single left shift (if the leftmost bit of x is nonzero, it'll be zeroed)
@@ -88,15 +86,8 @@ private:
 	const BitMatrix<2*N, 4*N> _lc;
 	const MultiQuadTuple<2*N, 2*N> _gu1;
 	const MultiQuadTuple<2*N, 2*N> _gu2;
-	const MultiQuadTuple<4*N, 3*N> _gb1;
-	const MultiQuadTuple<3*N, 3*N> _gb2;
-	const typename BridgeKey<N>::H_XOR _XOR;
-	const typename BridgeKey<N>::H_AND _AND;
-
-	const BitVector<3*N> binaryT(const BitVector<2*N> &x, const BitVector<2*N> &y) const{
-		const BitVector<4*N> & concatXY = BitVector<4*N>::template vCat<2*N, 2*N>(x, y);
-		return _gb2(_gb1(concatXY));
-	}
+	typename BridgeKey<N>::H_XOR _XOR;
+	typename BridgeKey<N>::H_AND _AND;
 };
 
 #endif


### PR DESCRIPTION
Remove all instances of A, B, as these matrices are not needed in the
final form of V1 Krypto (see paper).

This also solves the problem with Rx, Ry implementation before, and so supersedes the branch [RxRyImplementation](https://github.com/kryptnostic/krypto/tree/fix/RxRyImplementation).
